### PR TITLE
Fix: Highlight active page in header navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -407,6 +407,11 @@ footer div ul a span {
   transition: 0.3s;
 }
 
+.navbar .links ul li a.active {
+  color: #facc15;
+  transition: 0.3s;
+}
+
 .navbar .links ul:last-child {
   gap: 20px;
   display: flex;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 import {FaLinkedin, FaX, FaSquareGithub} from "react-icons/fa6"
 import {BsInstagram} from "react-icons/bs"
 import {GiHamburgerMenu} from "react-icons/gi"
@@ -29,6 +29,22 @@ const Navbar = () => {
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [show]);
 
+    const navItems = [
+        {
+            name: "HOME",
+            slug: "/"
+        },{
+            name: "DONATE US",
+            slug: "/donate"
+        },{
+            name: "ABOUT",
+            slug: "/about"
+        },{
+            name: "CONTACT",
+            slug: "/contact"
+        }
+    ]
+
     return (
         <>
             <nav className={show ? "navbar navbar_show" : "navbar"}>
@@ -37,10 +53,16 @@ const Navbar = () => {
                 </div>
                 <div className={`links ${show ? 'show' : ''}`}>
                     <ul>
-                        <li><Link to={"/"} onClick={() => setShow(false)}>HOME</Link></li>
-                        <li><Link to={"/donate"} onClick={() => setShow(false)}>DONATE US</Link></li>
-                        <li><Link to={"/about"} onClick={() => setShow(false)}>ABOUT</Link></li>
-                        <li><Link to={"/contact"} onClick={() => setShow(false)}>CONTACT</Link></li>
+                        {navItems.map((item)=>(
+                            <li onClick={() => setShow(false)}>
+                            <NavLink key={item.name} to={item.slug}  className={({isActive})=>`${isActive? "active":""}`}> 
+                                
+                                    {item.name}
+                                
+                            </NavLink>
+                            </li>
+                        ))}
+                        
                     </ul>
                     <ul>
                         <li>


### PR DESCRIPTION
### Fix: Header Navigation Now Highlights Active Page (Resolves #1)

## Description:
This pull request fixes the issue where header navigation links did not visually indicate the active page. The active state is now styled correctly using a CSS .active class, applied via NavLink from react-router-dom.

## Changes made:

1. Added the NavBar items as an array of objects.
2. Each object consists of a name (name of the navbar element) and slug (route).
3. This array is mapped via the .map() function of javaScript which makes it easier to add more NavBar items in the future.
4. Used <NavLink> from the react-router-dom to use the `isActive()` attribute to define a different css then the route is active.
5. Added a css class to take care of the active navBar items.

## Reference
**Before**

https://github.com/user-attachments/assets/172ed7b0-95cd-44c5-abe9-0f80eec69051


**After**

https://github.com/user-attachments/assets/f711ead8-8f71-4ab9-bf80-4127a985b524





This resolves Issue #1 raised by me.